### PR TITLE
feat: make library a little more typo-tolerant for shorthand

### DIFF
--- a/lib/src/entry.dart
+++ b/lib/src/entry.dart
@@ -20,12 +20,12 @@ class Entry {
 
   static double amountFromDenomination(double v, String denomination) {
     var amount = v;
-    if (denomination == 'k' ||
+    if (denomination == 'k' || (denomination == "j" || denomination == "l") || // j and l are typo-tolerant for k
         denomination == 'pin' ||
         denomination == 'grand') {
       amount = amount * 1000.00;
     } else if (denomination == 'mita' ||
-        denomination == 'm' ||
+        denomination == 'm' || (denomination == "n") || // n is typo-tolerant for m
         denomination == 'million') {
       amount = amount * 1000000.00;
     }

--- a/lib/src/fasa_base.dart
+++ b/lib/src/fasa_base.dart
@@ -10,7 +10,7 @@
   * <1 mita something else
   */
 final lineExprLTR = RegExp(
-    r'(<|\+|-|>)?\s?((\d*\.?\d{0,3})(k|K|pin|m|mita|grand)?)(\s?\w.*$)',
+    r'(<|\+|-|>)?\s?((\d*\.?\d{0,3})(k|K|j|J|l|L|pin|n|N|m|M|mita|grand)?)(\s?\w.*$)',
     multiLine: false,
     caseSensitive: false);
 
@@ -25,6 +25,6 @@ final lineExprLTR = RegExp(
   * something else <1 mita 
   */
 final lineExprRTL = RegExp(
-    r'(\s?\w.*)\s+(<|\+|-|>)?((\d*\.?\d{0,3})(k|K|pin|m|mita|grand)?)$',
+    r'(\s?\w.*)\s+(<|\+|-|>)?((\d*\.?\d{0,3})(k|K|j|J|l|L|pin|m|M|n|N|mita|grand)?)$',
     multiLine: false,
     caseSensitive: false);

--- a/test/fasa_test.dart
+++ b/test/fasa_test.dart
@@ -37,6 +37,8 @@ void main() {
       'potatoes 3000.00',
       'potatoes >3k',
       'potatoes +3k',
+      'potatoes +3j',
+      'potatoes +3l',
     ];
     for (var expr in expressions) {
       var entry = Entry.parseLineRTL(expr);


### PR DESCRIPTION
Sometimes people type too fast and would type `300l` instead of `300k` or `300j` instead of `300k` this changeset adds some tolerance for this class of user-error j and l suffixes are treated the same as k